### PR TITLE
Add the cytoscape.js sitemap

### DIFF
--- a/src/assets/js/cy.js
+++ b/src/assets/js/cy.js
@@ -1,0 +1,222 @@
+import my_nodes from "./cy_nodes.js"
+import my_edges from "./cy_edges.js"
+import cytoscape_dom_node from "./cytoscape-dom-node.js"
+
+cytoscape.use(cytoscape_dom_node);
+
+var cy = cytoscape({
+  container: $('#cy'),
+  style: [
+    {
+      selector: 'node',
+      style: {
+        'background-color': '#d2e2d3',
+        'font-family': 'Roboto',
+      },
+    },
+    {
+      selector: 'edge',
+      style: {
+        'line-color': '#ccc',
+        'target-arrow-color': '#ccc',
+        'target-arrow-shape': 'triangle',
+        'curve-style': 'round-taxi',
+        "taxi-turn": 10,
+        "taxi-turn-min-distance": 5,
+        "taxi-radius": 5,
+        
+      },
+      classes: ['multiline-auto']
+    },
+    {
+      selector: '.faded',
+      style: {
+        'opacity': 0.2
+      }
+    },
+    {
+      selector: '.highlighted',
+      style: {
+        'line-color': 'green',
+        'target-arrow-color': 'green',
+        'z-index': 999,
+        'border-color': 'green',
+        'border-width': 3,
+      }
+    }
+  ],
+  pixelRatio: 1.0,
+  wheelSensitivity: 0,
+  layout: {
+    name: 'preset'
+  }
+})
+
+cy.domNode();
+
+/**
+ * Add the HTML nodes.
+ */
+my_nodes.forEach((node) => {
+  let div = document.createElement("div");
+  if(node.data.url.length > 0) {
+    div.innerHTML = `
+    <div id='${node.data.id}' class='d-flex flex-row p-2 text-center justify-content-center align-items-center shadow rounded' style='width: 175px; border: 1px solid gray; border-radius: 5px;'>
+      <div class='px-1'>
+        ${node.data.icon}
+      </div>
+      <div class='px-1'>
+        <span style='font-size: 11px;'>${node.data.name}</span>
+      </div>
+      <div class='px-1'>
+        <button class='btn btn-link px-1 py-0' style="color: #429049;" onclick="window.open('${node.data.url}')">
+          <i class="fa-solid fa-arrow-right fa-rotate-by fa-xl" style="--fa-rotate-angle: -45deg;"></i>
+        </button>
+      </div>
+    </div>`;
+  } else {
+    div.innerHTML = `
+    <div id='${node.data.id}' class='d-flex flex-row p-2 text-center justify-content-center align-items-center shadow rounded' style='width: 175px; border: 1px solid gray; border-radius: 5px;'>
+      <div>
+        ${node.data.icon}
+      </div>
+      <div class='px-1'>
+        <span style='font-size: 11px;'>${node.data.name}</span>
+      </div>
+    </div>`;
+  }
+  
+  cy.add({
+    data: {
+      id: node.data.id,
+      dom: div,
+      url: node.data.url
+    },
+    position: {x: node.position.x, y: node.position.y}
+  })
+})
+
+/**
+ * Add the edges.
+ */
+my_edges.forEach((edge) => {
+  cy.add({
+    data: {
+      source: edge.data.source,
+      target: edge.data.target
+    }
+  })
+})
+
+// Lock the nodes and edges
+// cy.autolock( true );
+
+/**
+ * Tap control that removes all highlighted nodes, and edges
+ * when user clicks the graph body.
+ */
+cy.on('tap', (evt) => {
+  if(evt.target === cy) {
+    removeHighlighted()
+    removeFaded()
+  }
+})
+
+/**
+ * Tap control that highlights the selected node along with edges
+ * to targets, and source.
+ */
+cy.on('tap', 'node', (evt) => {
+  var i = 0
+  var targetEdges = cy.edges(`edge[source='${evt.target.data('id')}']`)
+  var children = targetEdges.targets()
+
+  removeHighlighted()
+  removeFaded()
+
+  let sourceEdges = cy.elements(`edge[target="${evt.target.data('id')}"]`)
+  sourceEdges.addClass('highlighted')
+  sourceEdges.forEach((elem) => {
+    let sourceNode = cy.elements(`node[id="${elem.data('source')}"]`)
+    sourceNode.addClass('highlighted')
+  })
+
+  evt.target.addClass('highlighted')
+
+  var highlightNextEle = () => {
+    if(i < children.length) {
+      children[i].addClass('highlighted')
+      targetEdges[i].addClass('highlighted')
+      i++
+      highlightNextEle()
+    }
+  }
+
+  highlightNextEle()
+  fadeUnselected()
+})
+
+/**
+ * Function for applying opacity to unselected nodes.
+ */
+function fadeUnselected() {
+  var allNodes = cy.nodes()
+  var allEdges = cy.edges()
+
+  allNodes.forEach((node) => {
+    if(node.classes().length == 0) {
+      node.addClass('faded')
+      $( `#${node.data().id}` ).addClass( "opacity-25" );
+    }
+  })
+  allEdges.forEach((edge) => {
+    if(edge.classes().length == 0) {
+      edge.addClass('faded')
+    }
+  })
+}
+
+/**
+ * Function for removing the highlight effect in all nodes, and edges.
+ */
+function removeHighlighted() {
+  cy.nodes().map((x) => {
+    x.removeClass('highlighted')
+  })
+  cy.edges().map((x) => {
+    x.removeClass('highlighted')
+  })
+}
+
+/**
+ * Function for removing the opacity effect in all nodes, and edges.
+ */
+function removeFaded() {
+  cy.nodes().map((node) => {
+    node.removeClass('faded')
+    $( `#${node.data().id}` ).removeClass( "opacity-25" );
+  })
+  cy.edges().map((edge) => {
+    edge.removeClass('faded')
+  })
+}
+
+/**
+ * Graph controls on the right side of the graph.
+ */
+$("#zoom-in").click(() => {
+  let currentZoom = cy.zoom()
+  cy.zoom(currentZoom + 0.050)
+})
+$("#zoom-out").click(() => {
+  let currentZoom = cy.zoom()
+  cy.zoom(currentZoom - 0.050)
+})
+$("#zoom-in").on('tap', () => {
+  let currentZoom = cy.zoom()
+  cy.zoom(currentZoom + 0.050)
+})
+$("#zoom-out").on('tap', () => {
+  let currentZoom = cy.zoom()
+  cy.zoom(currentZoom - 0.050)
+})

--- a/src/assets/js/cy_edges.js
+++ b/src/assets/js/cy_edges.js
@@ -1,0 +1,510 @@
+import nodes_config from "./nodes_config"
+const PLANTS = nodes_config.plants
+const SYSTEMS = nodes_config.systems
+const COMPONENTS = nodes_config.components
+const MEASUREMENT_TECHNIQUE = nodes_config.measurement_technicques
+const CALCULATION_METHODOLOGY = nodes_config.calculation_methodology
+
+export default [
+  /**
+   * 1st row
+   */
+  {
+    data: {
+      source: PLANTS.lighting_p.key,
+      target: SYSTEMS.lighting_fixture_s.key
+    },
+  },
+  {
+    data: {
+      source: PLANTS.lighting_p.key,
+      target: SYSTEMS.electrical_distribution_s.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.lighting_fixture_s.key,
+      target: MEASUREMENT_TECHNIQUE.lighting_fixture_runtime.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.lighting_fixture_runtime.key,
+      target: CALCULATION_METHODOLOGY.lighting_energy_consumption.key
+    }
+  },
+  /**
+   * 2nd row
+   */
+  {
+    data: {
+      source: SYSTEMS.electrical_distribution_s.key,
+      target: MEASUREMENT_TECHNIQUE.true_rms_power.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.electrical_distribution_s.key,
+      target: MEASUREMENT_TECHNIQUE.electrical_spot_measurements.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.electrical_distribution_s.key,
+      target: MEASUREMENT_TECHNIQUE.electrical_current.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.true_rms_power.key,
+      target: CALCULATION_METHODOLOGY.lighting_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.true_rms_power.key,
+      target: CALCULATION_METHODOLOGY.pump_motors_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.true_rms_power.key,
+      target: CALCULATION_METHODOLOGY.air_cooled_chiller_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.true_rms_power.key,
+      target: CALCULATION_METHODOLOGY.cooling_towers_fans_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.true_rms_power.key,
+      target: CALCULATION_METHODOLOGY.water_cooled_chiller_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.true_rms_power.key,
+      target: CALCULATION_METHODOLOGY.fan_motor_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.true_rms_power.key,
+      target: CALCULATION_METHODOLOGY.liquid_to_liquid_heat_exchanger_heat_transfer.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.true_rms_power.key,
+      target: CALCULATION_METHODOLOGY.air_to_air_heat_exchanger_heat_transfer.key
+    }
+  },
+  /**
+   * 3rd row
+   */
+  {
+    data: {
+      source: PLANTS.air_cooled_chilled_water_p.key,
+      target: SYSTEMS.chilled_water_loop.key
+    }
+  },
+  {
+    data: {
+      source: PLANTS.air_cooled_chilled_water_p.key,
+      target: SYSTEMS.air_cooled_chiller_s.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.chilled_water_loop.key,
+      target: COMPONENTS.const_spd_const_vol_pump_motor.key
+    }
+  },
+  {
+    data: {
+      source: COMPONENTS.var_spd_var_vol_pump_motor.key,
+      target: MEASUREMENT_TECHNIQUE.true_rms_power.key
+    }
+  },
+  {
+    data: {
+      source: COMPONENTS.var_spd_var_vol_pump_motor.key,
+      target: MEASUREMENT_TECHNIQUE.outdoor_air_temp.key
+    }
+  },
+  /**
+   * 4th row
+   */
+  {
+    data: {
+      source: SYSTEMS.air_cooled_chiller_s.key,
+      target: COMPONENTS.const_spd_const_vol_compressor_motor.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.electrical_spot_measurements.key,
+      target: CALCULATION_METHODOLOGY.lighting_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.electrical_spot_measurements.key,
+      target: CALCULATION_METHODOLOGY.pump_motors_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.electrical_spot_measurements.key,
+      target: CALCULATION_METHODOLOGY.cooling_towers_fans_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.electrical_spot_measurements.key,
+      target: CALCULATION_METHODOLOGY.fan_motor_energy_consumption.key
+    }
+  },
+  /**
+   * 5TH ROW
+   */
+  {
+    data: {
+      source: SYSTEMS.chilled_water_loop.key,
+      target: COMPONENTS.const_spd_const_vol_pump_motor.key
+    }
+  },
+  {
+    data: {
+      source: COMPONENTS.const_spd_const_vol_compressor_motor.key,
+      target: MEASUREMENT_TECHNIQUE.true_rms_power.key
+    }
+  },
+  {
+    data: {
+      source: COMPONENTS.const_spd_const_vol_compressor_motor.key,
+      target: MEASUREMENT_TECHNIQUE.outdoor_air_temp.key
+    }
+  },
+  {
+    data: {
+      source: COMPONENTS.const_spd_const_vol_compressor_motor.key,
+      target: MEASUREMENT_TECHNIQUE.pipe_surface_water_temp.key
+    }
+  },
+  {
+    data: {
+      source: COMPONENTS.const_spd_const_vol_compressor_motor.key,
+      target: MEASUREMENT_TECHNIQUE.water_flow_rate.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.electrical_current.key,
+      target: CALCULATION_METHODOLOGY.lighting_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.electrical_current.key,
+      target: CALCULATION_METHODOLOGY.fan_motor_energy_consumption.key
+    }
+  },
+  /**
+   * 6th row
+   */
+  {
+    data: {
+      source: PLANTS.water_cooled_chilled_water_p.key,
+      target: SYSTEMS.chilled_water_loop.key
+    }
+  },
+  {
+    data: {
+      source: PLANTS.water_cooled_chilled_water_p.key,
+      target: SYSTEMS.condenser_water_loop.key
+    }
+  },
+  {
+    data: {
+      source: PLANTS.water_cooled_chilled_water_p.key,
+      target: SYSTEMS.water_cooled_chiller.key
+    }
+  },
+  {
+    data: {
+      source: PLANTS.water_cooled_chilled_water_p.key,
+      target: SYSTEMS.waterside_economizer.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.condenser_water_loop.key,
+      target: COMPONENTS.const_spd_const_vol_pump_motor.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.condenser_water_loop.key,
+      target: COMPONENTS.const_spd_const_vol_fan_motor.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.condenser_water_loop.key,
+      target: COMPONENTS.var_spd_var_vol_fan_motor.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.motor_runtime.key,
+      target: CALCULATION_METHODOLOGY.pump_motors_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.motor_runtime.key,
+      target: CALCULATION_METHODOLOGY.cooling_towers_fans_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.motor_runtime.key,
+      target: CALCULATION_METHODOLOGY.fan_motor_energy_consumption.key
+    }
+  },
+  /**
+   * 7TH ROW
+   */
+  {
+    data: {
+      source: SYSTEMS.water_cooled_chiller.key,
+      target: COMPONENTS.const_spd_const_vol_compressor_motor.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.outdoor_air_temp.key,
+      target: CALCULATION_METHODOLOGY.pump_motors_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.outdoor_air_temp.key,
+      target: CALCULATION_METHODOLOGY.air_cooled_chiller_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.outdoor_air_temp.key,
+      target: CALCULATION_METHODOLOGY.cooling_towers_fans_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.outdoor_air_temp.key,
+      target: CALCULATION_METHODOLOGY.water_cooled_chiller_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.outdoor_air_temp.key,
+      target: CALCULATION_METHODOLOGY.fan_motor_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.outdoor_air_temp.key,
+      target: CALCULATION_METHODOLOGY.air_to_air_heat_exchanger_heat_transfer.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.waterside_economizer.key,
+      target: COMPONENTS.liquid_to_liquid_heat_exchanger.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.pipe_surface_water_temp.key,
+      target: CALCULATION_METHODOLOGY.air_cooled_chiller_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.pipe_surface_water_temp.key,
+      target: CALCULATION_METHODOLOGY.water_cooled_chiller_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.pipe_surface_water_temp.key,
+      target: CALCULATION_METHODOLOGY.liquid_to_liquid_heat_exchanger_heat_transfer.key
+    }
+  },
+  {
+    data: {
+      source: PLANTS.air_handling_p.key,
+      target: SYSTEMS.const_spd_const_vol_air_handling_unit.key
+    }
+  },
+  {
+    data: {
+      source: PLANTS.air_handling_p.key,
+      target: SYSTEMS.var_spd_var_vol_air_handling_unit.key
+    }
+  },
+  {
+    data: {
+      source: PLANTS.air_handling_p.key,
+      target: SYSTEMS.air_to_air_energy_recovery.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.relative_humid.key,
+      target: CALCULATION_METHODOLOGY.cooling_towers_fans_energy_consumption.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.relative_humid.key,
+      target: CALCULATION_METHODOLOGY.air_to_air_heat_exchanger_heat_transfer.key
+    }
+  },
+  {
+    data: {
+      source: PLANTS.hot_water_heating_p.key,
+      target: SYSTEMS.boiler.key
+    }
+  },
+  {
+    data: {
+      source: PLANTS.hot_water_heating_p.key,
+      target: SYSTEMS.hot_water_loop.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.boiler.key,
+      target: COMPONENTS.const_spd_const_vol_fan_motor.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.boiler.key,
+      target: COMPONENTS.var_spd_var_vol_fan_motor.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.hot_water_loop.key,
+      target: COMPONENTS.const_spd_const_vol_pump_motor.key
+    }
+  },
+  {
+    data: {
+      source: COMPONENTS.liquid_to_liquid_heat_exchanger.key,
+      target: MEASUREMENT_TECHNIQUE.pipe_surface_water_temp.key
+    }
+  },
+  {
+    data: {
+      source: COMPONENTS.liquid_to_liquid_heat_exchanger.key,
+      target: MEASUREMENT_TECHNIQUE.water_flow_rate.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.air_flow_rate.key,
+      target: CALCULATION_METHODOLOGY.air_to_air_heat_exchanger_heat_transfer.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.feedwater_s.key,
+      target: COMPONENTS.const_spd_const_vol_pump_motor.key
+    }
+  },
+  {
+    data: {
+      source: PLANTS.steam_p.key,
+      target: SYSTEMS.boiler.key
+    }
+  },
+  {
+    data: {
+      source: PLANTS.steam_p.key,
+      target: SYSTEMS.feedwater_s.key
+    }
+  },
+  {
+    data: {
+      source: PLANTS.steam_p.key,
+      target: SYSTEMS.steam_condensate_recovery_s.key
+    }
+  },
+  {
+    data: {
+      source: PLANTS.steam_p.key,
+      target: SYSTEMS.steam_distribution_s.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.steam_condensate_recovery_s.key,
+      target: COMPONENTS.const_spd_const_vol_pump_motor.key
+    }
+  },
+  {
+    data: {
+      source: COMPONENTS.air_to_air_heat_exchanger.key,
+      target: MEASUREMENT_TECHNIQUE.true_rms_power.key
+    }
+  },
+  {
+    data: {
+      source: COMPONENTS.air_to_air_heat_exchanger.key,
+      target: MEASUREMENT_TECHNIQUE.outdoor_air_temp.key
+    }
+  },
+  {
+    data: {
+      source: COMPONENTS.air_to_air_heat_exchanger.key,
+      target: MEASUREMENT_TECHNIQUE.relative_humid.key
+    }
+  },
+  {
+    data: {
+      source: COMPONENTS.air_to_air_heat_exchanger.key,
+      target: MEASUREMENT_TECHNIQUE.air_flow_rate.key
+    }
+  },
+  {
+    data: {
+      source: COMPONENTS.air_to_air_heat_exchanger.key,
+      target: MEASUREMENT_TECHNIQUE.system_air_temp.key
+    }
+  },
+  {
+    data: {
+      source: MEASUREMENT_TECHNIQUE.system_air_temp.key,
+      target: CALCULATION_METHODOLOGY.air_to_air_heat_exchanger_heat_transfer.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.steam_distribution_s.key,
+      target: COMPONENTS.const_spd_const_vol_pump_motor.key
+    }
+  },
+  {
+    data: {
+      source: SYSTEMS.steam_distribution_s.key,
+      target: COMPONENTS.var_spd_var_vol_pump_motor.key
+    }
+  },
+]

--- a/src/assets/js/cy_nodes.js
+++ b/src/assets/js/cy_nodes.js
@@ -1,0 +1,508 @@
+import nodes_config from "./nodes_config"
+const PLANTS = nodes_config.plants
+const SYSTEMS = nodes_config.systems
+const COMPONENTS = nodes_config.components
+const MEASUREMENT_TECHNIQUE = nodes_config.measurement_technicques
+const CALCULATION_METHODOLOGY = nodes_config.calculation_methodology
+const COL_1 = 120
+const COL_2 = 430
+const COL_3 = 750
+const COL_4 = 1075
+const COL_5 = 1400
+const ROW_1 = 100
+const ROW_2 = 225
+const ROW_3 = 350
+const ROW_4 = 475
+const ROW_5 = 600
+const ROW_6 = 725
+const ROW_7 = 850
+const ROW_8 = 975
+const ROW_9 = 1100
+const ROW_10 = 1225
+const ROW_11 = 1350
+const ROW_12 = 1475
+const ROW_13 = 1600
+const ROW_14 = 1725
+const ROW_15 = 1850
+const ROW_16 = 1975
+const ICON_PLANT = '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M480-240q100 0 170-70t70-170q0-100-70-170t-170-70q-100 0-170 70t-70 170q0 100 70 170t170 70Zm0-80q-29 0-56-10.5T375-360h210q-22 19-49 29.5T480-320Zm-138-80q-8-14-13-29t-7-31h316q-2 16-7 31t-13 29H342Zm-20-100q2-16 7-31t13-29h276q8 14 13 29t7 31H322Zm53-100q22-19 49-29.5t56-10.5q29 0 56 10.5t49 29.5H375ZM200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Zm0-80h560v-560H200v560Zm0-560v560-560Z"/></svg>'
+const ICON_SYSTEM = '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M372-529q0 19 6.5 37t18.5 33q2-12 8-23.5t15-19.5l60-58 59 59q9 8 15 19t8 23q11-15 19.5-32t8.5-36q0-19-6-36.5T566-596q-11 5-22.5 8t-23.5 3q-30 0-55-17t-38-45q-12 12-22 25.5T387.5-593q-7.5 15-11.5 31t-4 33Zm108 53-17 17q-4 4-5.5 8t-1.5 9q0 10 7 16t17 6q10 0 17-6t7-16q0-5-1.5-9t-5.5-8l-17-17Zm0-284v76q0 17 12 28.5t29 11.5q11 0 20-6.5t16-15.5l7-10q41 23 63.5 62.5T650-527q0 70-50 118.5T480-360q-70 0-119-49t-49-119q0-77 49-137t119-95ZM240-80q-33 0-56.5-23.5T160-160v-560q0-66 47-113t113-47h320q66 0 113 47t47 113v560q0 33-23.5 56.5T720-80H240Zm0-160v80h480v-80q-30 0-48 20t-72 20q-54 0-70.5-20T480-240q-33 0-49.5 20T360-200q-54 0-70.5-20T240-240Zm120-40q33 0 49.5-20t70.5-20q54 0 72 20t48 20q30 0 48-20t72-20v-400q0-33-23.5-56.5T640-800H320q-33 0-56.5 23.5T240-720v400q54 0 70.5 20t49.5 20Z"/></svg>'
+const ICON_COMPONENT = '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M424-80q-51 0-77.5-30.5T320-180q0-26 11.5-50.5T367-271q22-14 35.5-36t18.5-47l-12-6q-6-3-11-7l-92 33q-17 6-33 10t-33 4q-63 0-111.5-55T80-536q0-51 30.5-77.5T179-640q26 0 51 11.5t41 35.5q14 22 36 35.5t47 18.5l6-12q3-6 7-11l-33-92q-6-17-10-33t-4-32q0-64 55-112.5T536-880q51 0 77.5 30.5T640-781q0 26-11.5 51T593-689q-22 14-35.5 36T539-606l12 6q6 3 11 7l92-34q17-6 32.5-9.5T719-640q81 0 121 67t40 149q0 51-32 77.5T777-320q-25 0-48.5-11.5T689-367q-14-22-36-35.5T606-421l-6 12q-3 6-7 11l33 92q6 16 10 30.5t4 30.5q1 65-54 115T424-80Zm56-340q25 0 42.5-17.5T540-480q0-25-17.5-42.5T480-540q-25 0-42.5 17.5T420-480q0 25 17.5 42.5T480-420Zm-46-192q6-2 12.5-3.5T459-618q8-42 30.5-78t59.5-60q5-4 8-10t3-15q0-8-6-13.5t-18-5.5q-38 0-86 16.5T400-719q0 9 2.5 17t4.5 15l27 75ZM240-400q14 0 33-7l75-27q-2-6-3.5-12.5T342-459q-42-8-78-30.5T204-549q-4-5-10.5-8t-14.5-3q-9 0-14 6t-5 18q0 54 20.5 95t59.5 41Zm184 240q47 0 92.5-19t43.5-66q0-8-2.5-15t-4.5-13l-27-75q-6 2-12.5 3.5T501-342q-8 42-30.5 78T411-204q-5 4-8.5 10.5T400-180q1 8 6 14t18 6Zm353-240q9 0 16-5t7-19q0-38-16-86.5T719-560q-9 0-17 2t-15 4l-75 28q2 6 3.5 12.5T618-501q42 8 78 30.5t60 59.5q3 5 9 8t12 3ZM618-501ZM459-618ZM342-459Zm159 117Z"/></svg>'
+const ICON_CALC = '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M240-160v-80l260-240-260-240v-80h480v120H431l215 200-215 200h289v120H240Z"/></svg>'
+const ICON_MEASUREMENT = '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520v-200H240v640h480v-440H520ZM240-800v200-200 640-640Z"/></svg>'
+
+export default [
+  /**
+   * 1st row
+   */
+  {
+    data: {
+      id: PLANTS.lighting_p.key, 
+      name: PLANTS.lighting_p.name, 
+      url: PLANTS.lighting_p.url,
+      icon: ICON_PLANT
+    },
+    position: {x: COL_1, y: ROW_1}
+  },
+   {
+     data: {
+       id: SYSTEMS.lighting_fixture_s.key, 
+       name: SYSTEMS.lighting_fixture_s.name, 
+       url: SYSTEMS.lighting_fixture_s.url,
+       icon: ICON_SYSTEM
+     },
+     position: {x: COL_2, y: ROW_1}
+   },
+  {
+    data: {
+      id: COMPONENTS.const_spd_const_vol_pump_motor.key,
+      name: COMPONENTS.const_spd_const_vol_pump_motor.name,
+      url: COMPONENTS.const_spd_const_vol_pump_motor.url,
+      icon: ICON_COMPONENT
+    },
+    position: {x: COL_3, y: ROW_1}
+  },
+  {
+    data: {
+      id: MEASUREMENT_TECHNIQUE.lighting_fixture_runtime.key,
+      name: MEASUREMENT_TECHNIQUE.lighting_fixture_runtime.name,
+      url: MEASUREMENT_TECHNIQUE.lighting_fixture_runtime.url,
+      icon: ICON_MEASUREMENT
+    },
+    position: {x: COL_4, y: ROW_1}
+  },
+  {
+    data: {
+      id: CALCULATION_METHODOLOGY.lighting_energy_consumption.key,
+      name: CALCULATION_METHODOLOGY.lighting_energy_consumption.name,
+      url: CALCULATION_METHODOLOGY.lighting_energy_consumption.url,
+      icon: ICON_CALC
+    },
+    position: {x: COL_5, y: ROW_1}
+  },
+  /**
+   * 2nd row
+   */
+  {
+    data: {
+      id: SYSTEMS.electrical_distribution_s.key, 
+      name: SYSTEMS.electrical_distribution_s.name, 
+      url: SYSTEMS.electrical_distribution_s.url,
+      icon: ICON_SYSTEM
+    },
+    position: {x: COL_2, y: ROW_2}
+  },
+  {
+    data: {
+      id: MEASUREMENT_TECHNIQUE.true_rms_power.key,
+      name: MEASUREMENT_TECHNIQUE.true_rms_power.name,
+      url: MEASUREMENT_TECHNIQUE.true_rms_power.url,
+      icon: ICON_MEASUREMENT
+    },
+    position: {x: COL_4, y: ROW_2}
+  },
+  {
+    data: {
+      id: CALCULATION_METHODOLOGY.pump_motors_energy_consumption.key,
+      name: CALCULATION_METHODOLOGY.pump_motors_energy_consumption.name,
+      url: CALCULATION_METHODOLOGY.pump_motors_energy_consumption.url,
+      icon: ICON_CALC
+    },
+    position: {x: COL_5, y: ROW_2}
+  },
+  /**
+   * 3rd row
+   */
+  {
+    data: {
+      id: PLANTS.air_cooled_chilled_water_p.key, 
+      name: PLANTS.air_cooled_chilled_water_p.name, 
+      url: PLANTS.air_cooled_chilled_water_p.url,
+      icon: ICON_PLANT
+    },
+    position: {x: COL_1, y: ROW_3}
+  },
+  {
+    data: {
+      id: COMPONENTS.var_spd_var_vol_pump_motor.key,
+      name: COMPONENTS.var_spd_var_vol_pump_motor.name,
+      url: COMPONENTS.var_spd_var_vol_pump_motor.url,
+      icon: ICON_COMPONENT
+    },
+    position: {x: COL_3, y: ROW_3}
+  },
+  {
+    data: {
+      id: CALCULATION_METHODOLOGY.air_cooled_chiller_energy_consumption.key,
+      name: CALCULATION_METHODOLOGY.air_cooled_chiller_energy_consumption.name,
+      url: CALCULATION_METHODOLOGY.air_cooled_chiller_energy_consumption.url,
+      icon: ICON_CALC
+    },
+    position: {x: COL_5, y: ROW_3}
+  },
+  /**
+   * 4th row
+   */
+  {
+    data: {
+      id: SYSTEMS.air_cooled_chiller_s.key, 
+      name: SYSTEMS.air_cooled_chiller_s.name, 
+      url: SYSTEMS.air_cooled_chiller_s.url,
+      icon: ICON_SYSTEM
+    },
+    position: {x: COL_2, y: ROW_4}
+  },
+  {
+    data: {
+      id: MEASUREMENT_TECHNIQUE.electrical_spot_measurements.key,
+      name: MEASUREMENT_TECHNIQUE.electrical_spot_measurements.name,
+      url: MEASUREMENT_TECHNIQUE.electrical_spot_measurements.url,
+      icon: ICON_MEASUREMENT
+    },
+    position: {x: COL_4, y: ROW_4}
+  },
+  /**
+   * 5th row
+   */
+  {
+    data: {
+      id: SYSTEMS.chilled_water_loop.key, 
+      name: SYSTEMS.chilled_water_loop.name, 
+      url: SYSTEMS.chilled_water_loop.url,
+      icon: ICON_SYSTEM
+    },
+    position: {x: COL_2, y: ROW_5}
+  },
+  {
+    data: {
+      id: COMPONENTS.const_spd_const_vol_compressor_motor.key,
+      name: COMPONENTS.const_spd_const_vol_compressor_motor.name,
+      url: COMPONENTS.const_spd_const_vol_compressor_motor.url,
+      icon: ICON_COMPONENT
+    },
+    position: {x: COL_3, y: ROW_5}
+  },
+  {
+    data: {
+      id: MEASUREMENT_TECHNIQUE.electrical_current.key,
+      name: MEASUREMENT_TECHNIQUE.electrical_current.name,
+      url: MEASUREMENT_TECHNIQUE.electrical_current.url,
+      icon: ICON_MEASUREMENT
+    },
+    position: {x: COL_4, y: ROW_5}
+  },
+  {
+    data: {
+      id: CALCULATION_METHODOLOGY.cooling_towers_fans_energy_consumption.key,
+      name: CALCULATION_METHODOLOGY.cooling_towers_fans_energy_consumption.name,
+      url: CALCULATION_METHODOLOGY.cooling_towers_fans_energy_consumption.url,
+      icon: ICON_CALC
+    },
+    position: {x: COL_5, y: ROW_5}
+  },
+  /**
+   * 6th row
+   */
+  {
+    data: {
+      id: PLANTS.water_cooled_chilled_water_p.key, 
+      name: PLANTS.water_cooled_chilled_water_p.name, 
+      url: PLANTS.water_cooled_chilled_water_p.url,
+      icon: ICON_PLANT
+    },
+    position: {x: COL_1, y: ROW_6}
+  },
+  {
+    data: {
+      id: SYSTEMS.condenser_water_loop.key, 
+      name: SYSTEMS.condenser_water_loop.name, 
+      url: SYSTEMS.condenser_water_loop.url,
+      icon: ICON_SYSTEM
+    },
+    position: {x: COL_2, y: ROW_6}
+  },
+  {
+    data: {
+      id: MEASUREMENT_TECHNIQUE.motor_runtime.key,
+      name: MEASUREMENT_TECHNIQUE.motor_runtime.name,
+      url: MEASUREMENT_TECHNIQUE.motor_runtime.url,
+      icon: ICON_MEASUREMENT
+    },
+    position: {x: COL_4, y: ROW_6}
+  },
+  /**
+   * 7th row
+   */
+  {
+    data: {
+      id: SYSTEMS.water_cooled_chiller.key, 
+      name: SYSTEMS.water_cooled_chiller.name, 
+      url: SYSTEMS.water_cooled_chiller.url,
+      icon: ICON_SYSTEM
+    },
+    position: {x: COL_2, y: ROW_7}
+  },
+  {
+    data: {
+      id: MEASUREMENT_TECHNIQUE.outdoor_air_temp.key,
+      name: MEASUREMENT_TECHNIQUE.outdoor_air_temp.name,
+      url: MEASUREMENT_TECHNIQUE.outdoor_air_temp.url,
+      icon: ICON_MEASUREMENT
+    },
+    position: {x: COL_4, y: ROW_7}
+  },
+  {
+    data: {
+      id: CALCULATION_METHODOLOGY.water_cooled_chiller_energy_consumption.key,
+      name: CALCULATION_METHODOLOGY.water_cooled_chiller_energy_consumption.name,
+      url: CALCULATION_METHODOLOGY.water_cooled_chiller_energy_consumption.url,
+      icon: ICON_CALC
+    },
+    position: {x: COL_5, y: ROW_7}
+  },
+
+  /**
+   * 
+   */
+  {
+    data: {
+      id: SYSTEMS.waterside_economizer.key,
+      name: SYSTEMS.waterside_economizer.name,
+      url: SYSTEMS.waterside_economizer.url,
+      icon: ICON_SYSTEM
+    },
+    position: {x: COL_2, y: ROW_8}
+  },
+  {
+    data: {
+      id: MEASUREMENT_TECHNIQUE.pipe_surface_water_temp.key,
+      name: MEASUREMENT_TECHNIQUE.pipe_surface_water_temp.name,
+      url: MEASUREMENT_TECHNIQUE.pipe_surface_water_temp.url,
+      icon: ICON_MEASUREMENT
+    },
+    position: {x: COL_4, y: ROW_8}
+  },
+  /**
+   * 8th row
+   */
+
+  {
+    data: {
+      id: PLANTS.air_handling_p.key, 
+      name: PLANTS.air_handling_p.name, 
+      url: PLANTS.air_handling_p.url,
+      icon: ICON_PLANT
+    },
+    position: {x: COL_1, y: ROW_9}
+  },
+  {
+    data: {
+      id: SYSTEMS.const_spd_const_vol_air_handling_unit.key,
+      name: SYSTEMS.const_spd_const_vol_air_handling_unit.name,
+      url: SYSTEMS.const_spd_const_vol_air_handling_unit.url,
+      icon: ICON_SYSTEM
+    },
+    position: {x: COL_2, y: ROW_9}
+  },
+  {
+    data: {
+      id: COMPONENTS.const_spd_const_vol_fan_motor.key,
+      name: COMPONENTS.const_spd_const_vol_fan_motor.name,
+      url: COMPONENTS.const_spd_const_vol_fan_motor.url,
+      icon: ICON_COMPONENT
+    },
+    position: {x: COL_3, y: ROW_9}
+  },
+  {
+    data: {
+      id: MEASUREMENT_TECHNIQUE.water_flow_rate.key,
+      name: MEASUREMENT_TECHNIQUE.water_flow_rate.name,
+      url: MEASUREMENT_TECHNIQUE.water_flow_rate.url,
+      icon: ICON_MEASUREMENT
+    },
+    position: {x: COL_4, y: ROW_9}
+  },
+  /**
+   * 9th row
+   */
+  {
+    data: {
+      id: SYSTEMS.var_spd_var_vol_air_handling_unit.key,
+      name: SYSTEMS.var_spd_var_vol_air_handling_unit.name,
+      url: SYSTEMS.var_spd_var_vol_air_handling_unit.url,
+      icon: ICON_SYSTEM
+    },
+    position: {x: COL_2, y: ROW_10}
+  },
+  {
+    data: {
+      id: CALCULATION_METHODOLOGY.fan_motor_energy_consumption.key,
+      name: CALCULATION_METHODOLOGY.fan_motor_energy_consumption.name,
+      url: CALCULATION_METHODOLOGY.fan_motor_energy_consumption.url,
+      icon: ICON_CALC
+    },
+    position: {x: COL_5, y: ROW_10}
+  },
+  /**
+   * 10th row
+   */
+  {
+    data: {
+      id: SYSTEMS.air_to_air_energy_recovery.key,
+      name: SYSTEMS.air_to_air_energy_recovery.name,
+      url: SYSTEMS.air_to_air_energy_recovery.url,
+      icon: ICON_SYSTEM
+    },
+    position: {x: COL_2, y: ROW_11}
+  },
+  {
+    data: {
+      id: COMPONENTS.var_spd_var_vol_fan_motor.key,
+      name: COMPONENTS.var_spd_var_vol_fan_motor.name,
+      url: COMPONENTS.var_spd_var_vol_fan_motor.url,
+      icon: ICON_COMPONENT
+    },
+    position: {x: COL_3, y: ROW_11}
+  },
+  {
+    data: {
+      id: MEASUREMENT_TECHNIQUE.relative_humid.key,
+      name: MEASUREMENT_TECHNIQUE.relative_humid.name,
+      url: MEASUREMENT_TECHNIQUE.relative_humid.url,
+      icon: ICON_MEASUREMENT
+    },
+    position: {x: COL_4, y: ROW_11}
+  },
+  /**
+   * 11th row
+   */
+  {
+    data: {
+      id: PLANTS.hot_water_heating_p.key, 
+      name: PLANTS.hot_water_heating_p.name, 
+      url: PLANTS.hot_water_heating_p.url,
+      icon: ICON_PLANT
+    },
+    position: {x: COL_1, y: ROW_12}
+  },
+  {
+    data: {
+      id: SYSTEMS.boiler.key,
+      name: SYSTEMS.boiler.name,
+      url: SYSTEMS.boiler.url,
+      icon: ICON_SYSTEM
+    },
+    position: {x: COL_2, y: ROW_12}
+  },
+  /**
+   * 12th row
+   */
+  {
+    data: {
+      id: SYSTEMS.hot_water_loop.key,
+      name: SYSTEMS.hot_water_loop.name,
+      url: SYSTEMS.hot_water_loop.url,
+      icon: ICON_SYSTEM
+    },
+    position: {x: COL_2, y: ROW_13}
+  },
+  {
+    data: {
+      id: COMPONENTS.liquid_to_liquid_heat_exchanger.key,
+      name: COMPONENTS.liquid_to_liquid_heat_exchanger.name,
+      url: COMPONENTS.liquid_to_liquid_heat_exchanger.url,
+      icon: ICON_COMPONENT
+    },
+    position: {x: COL_3, y: ROW_13}
+  },
+  {
+    data: {
+      id: MEASUREMENT_TECHNIQUE.air_flow_rate.key,
+      name: MEASUREMENT_TECHNIQUE.air_flow_rate.name,
+      url: MEASUREMENT_TECHNIQUE.air_flow_rate.url,
+      icon: ICON_MEASUREMENT
+    },
+    position: {x: COL_4, y: ROW_13}
+  },
+  {
+    data: {
+      id: CALCULATION_METHODOLOGY.liquid_to_liquid_heat_exchanger_heat_transfer.key,
+      name: CALCULATION_METHODOLOGY.liquid_to_liquid_heat_exchanger_heat_transfer.name,
+      url: CALCULATION_METHODOLOGY.liquid_to_liquid_heat_exchanger_heat_transfer.url,
+      icon: ICON_CALC
+    },
+    position: {x: COL_5, y: ROW_13}
+  },
+  /**
+   * 13th row
+   */
+  {
+    data: {
+      id: SYSTEMS.feedwater_s.key,
+      name: SYSTEMS.feedwater_s.name,
+      url: SYSTEMS.feedwater_s.url,
+      icon: ICON_SYSTEM
+    },
+    position: {x: COL_2, y: ROW_14}
+  },
+  /**
+   * 14th row
+   */
+  {
+    data: {
+      id: PLANTS.steam_p.key, 
+      name: PLANTS.steam_p.name, 
+      url: PLANTS.steam_p.url,
+      icon: ICON_PLANT
+    },
+    position: {x: COL_1, y: ROW_15}
+  },
+  {
+    data: {
+      id: SYSTEMS.steam_condensate_recovery_s.key,
+      name: SYSTEMS.steam_condensate_recovery_s.name,
+      url: SYSTEMS.steam_condensate_recovery_s.url,
+      icon: ICON_SYSTEM
+    },
+    position: {x: COL_2, y: ROW_15}
+  },
+  {
+    data: {
+      id: COMPONENTS.air_to_air_heat_exchanger.key,
+      name: COMPONENTS.air_to_air_heat_exchanger.name,
+      url: COMPONENTS.air_to_air_heat_exchanger.url,
+      icon: ICON_COMPONENT
+    },
+    position: {x: COL_3, y: ROW_15}
+  },
+  {
+    data: {
+      id: MEASUREMENT_TECHNIQUE.system_air_temp.key,
+      name: MEASUREMENT_TECHNIQUE.system_air_temp.name,
+      url: MEASUREMENT_TECHNIQUE.system_air_temp.url,
+      icon: ICON_MEASUREMENT
+    },
+    position: {x: COL_4, y: ROW_15}
+  },
+  {
+    data: {
+      id: CALCULATION_METHODOLOGY.air_to_air_heat_exchanger_heat_transfer.key,
+      name: CALCULATION_METHODOLOGY.air_to_air_heat_exchanger_heat_transfer.name,
+      url: CALCULATION_METHODOLOGY.air_to_air_heat_exchanger_heat_transfer.url,
+      icon: ICON_CALC
+    },
+    position: {x: COL_5, y: ROW_15}
+  },
+  /**
+   * 15th row
+   */
+  {
+    data: {
+      id: SYSTEMS.steam_distribution_s.key,
+      name: SYSTEMS.steam_distribution_s.name,
+      url: SYSTEMS.steam_distribution_s.url,
+      icon: ICON_SYSTEM
+    },
+    position: {x: COL_2, y: ROW_16}
+  }
+]

--- a/src/assets/js/cytoscape-dom-node.js
+++ b/src/assets/js/cytoscape-dom-node.js
@@ -1,0 +1,104 @@
+class CytoscapeDomNode {
+  constructor (cy, params = {}) {
+      this._cy       = cy;
+      this._params   = params;
+      this._node_dom = {};
+
+      let cy_container = cy.container();
+
+      if (params.dom_container) {
+          this._nodes_dom_container = params.dom_container;
+      } else {
+          let nodes_dom_container = document.createElement("div");
+          nodes_dom_container.style.position = 'absolute';
+          nodes_dom_container.style.zIndex = 10;
+
+          let cy_canvas = cy_container.querySelector("canvas");
+          cy_canvas.parentNode.appendChild(nodes_dom_container);
+
+          this._nodes_dom_container = nodes_dom_container;
+      }
+
+      this._resize_observer = new ResizeObserver((entries) => {
+          for (let e of entries) {
+              let node_div = e.target;
+              let id = node_div.__cy_id;
+              let n  = cy.getElementById(id);
+              n.style({'width': node_div.offsetWidth, 'height': node_div.offsetHeight, shape: 'rectangle'});
+          }
+      });
+
+      cy.on('add', 'node', (ev) => {
+          this._add_node(ev.target);
+      });
+
+      for (let n of cy.nodes())
+          this._add_node(n);
+
+      cy.on("pan zoom", (ev) => {
+          let pan  = cy.pan();
+          let zoom = cy.zoom();
+
+          let transform = "translate(" + pan.x + "px," + pan.y + "px) scale(" + zoom + ")";
+          this._nodes_dom_container.style.msTransform = transform;
+          this._nodes_dom_container.style.transform = transform;
+      });
+
+      cy.on('position bounds', 'node', (ev) => {
+          let cy_node = ev.target;
+          let id      = cy_node.id();
+
+          if (!this._node_dom[id])
+              return;
+
+          let dom = this._node_dom[id];
+
+          let style_transform = `translate(-50%, -50%) translate(${cy_node.position('x').toFixed(2)}px, ${cy_node.position('y').toFixed(2)}px)`;
+          dom.style.webkitTransform = style_transform;
+          dom.style.msTransform     = style_transform;
+          dom.style.transform       = style_transform;
+
+          dom.style.display = 'inline';
+          dom.style.position = 'absolute';
+          dom.style['z-index'] = 10;
+      });
+  }
+
+  _add_node (n) {
+      let data = n.data();
+
+      if (!data.dom)
+          return;
+
+      if (data.skip_node_append !== true) {
+          this._nodes_dom_container.appendChild(data.dom);
+      }
+      data.dom.__cy_id = n.id();
+
+      this._node_dom[n.id()] = data.dom;
+
+      this._resize_observer.observe(data.dom);
+  }
+
+  node_dom (id) {
+      return this._node_dom[id];
+  }
+}
+
+
+function register (cy) {
+  if (!cy)
+      return;
+
+  cy('core', 'domNode', function (params, opts) {
+      return new CytoscapeDomNode(this, params, opts);
+  });
+}
+
+
+if (typeof(cytoscape) !== 'undefined') {
+  register(cytoscape);
+}
+
+
+export default register;

--- a/src/assets/js/nodes_config.js
+++ b/src/assets/js/nodes_config.js
@@ -1,0 +1,257 @@
+export default {
+  "plants": {
+      "lighting_p": {
+          "key": "p_node_1",
+          "name": "Lighting Plant",
+          "url": "https://uat-pnp.nycenergytools.com/documents/plants/lighting-plant/"
+      },
+      "air_cooled_chilled_water_p": {
+          "key": "p_node_2",
+          "name": "Air-cooled Chilled Water Plant",
+          "url": "https://uat-pnp.nycenergytools.com/documents/plants/air-cooled-chilled-water-plant/"
+      },
+      "water_cooled_chilled_water_p": {
+          "key": "p_node_3",
+          "name": "Water-cooled Chilled Water Plant",
+          "url": "https://uat-pnp.nycenergytools.com/documents/plants/water-cooled-chilled-water-plant/"
+      },
+      "air_handling_p": {
+          "key": "p_node_4",
+          "name": "Air Handling Plant",
+          "url": "https://uat-pnp.nycenergytools.com/documents/plants/air-handling-plant/"
+      },
+      "hot_water_heating_p": {
+          "key": "p_node_5",
+          "name": "Hot-water Heating Plant",
+          "url": "https://uat-pnp.nycenergytools.com/documents/plants/hot-water-heating-plant/"
+      },
+      "steam_p": {
+          "key": "p_node_6",
+          "name": "Steam Plant",
+          "url": "https://uat-pnp.nycenergytools.com/documents/plants/steam-plant/"
+      }
+  },
+  "systems": {
+      "lighting_fixture_s": {
+          "key": "s_node_1",
+          "name": "Lighting Fixture System",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/lighting-fixture/"
+      },
+      "electrical_distribution_s": {
+          "key": "s_node_2",
+          "name": "Electrical Distribution System",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/electrical-distribution/"
+      },
+      "chilled_water_loop_s": {
+          "key": "s_node_3",
+          "name": "Chilled Water Loop System",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/chilled-water-loop/"
+      },
+      "air_cooled_chiller_s": {
+          "key": "s_node_4",
+          "name": "Air-cooled Chiller System",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/air-cooled-chiller/"
+      },
+      "chilled_water_loop": {
+          "key": "s_node_5",
+          "name": "Chilled Water Loop",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/chilled-water-loop/"
+      },
+      "condenser_water_loop": {
+          "key": "s_node_6",
+          "name": "Condenser Water Loop",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/condenser-water-loop/"
+      },
+      "water_cooled_chiller": {
+          "key": "s_node_7",
+          "name": "Water-cooled Chiller",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/water-cooled-chiller/"
+      },
+      "waterside_economizer": {
+          "key": "s_node_8",
+          "name": "Waterside Economizer",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/waterside-economizer/"
+      },
+      "const_spd_const_vol_air_handling_unit": {
+          "key": "s_node_9",
+          "name": "Constant-speed, Constant-volume Air Handling Unit",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/constant-speed-constant-volume-air-handling-system/"
+      },
+      "var_spd_var_vol_air_handling_unit": {
+          "key": "s_node_10",
+          "name": "Variable-speed, Variable-volume Air Handling Unit",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/variable-speed-variable-volume-air-handling-system/"
+      },
+      "air_to_air_energy_recovery": {
+          "key": "s_node_11",
+          "name": "Air-to-air Energy Recovery",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/air-to-air-energy-recovery/"
+      },
+      "boiler": {
+          "key": "s_node_12",
+          "name": "Boiler",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/boiler/"
+      },
+      "hot_water_loop": {
+          "key": "s_node_13",
+          "name": "Hot Water Loop",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/hot-water-loop/"
+      },
+      "feedwater_s": {
+          "key": "s_node_14",
+          "name": "Feedwater System",
+          "url": ""
+      },
+      "steam_condensate_recovery_s": {
+          "key": "s_node_15",
+          "name": "Steam Condensate Recovery System",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/steam-condensate-recovery/"
+      },
+      "steam_distribution_s": {
+          "key": "s_node_16",
+          "name": "Steam Distribution System",
+          "url": "https://uat-pnp.nycenergytools.com/documents/systems/steam-distribution/"
+      }
+  },
+  "components": {
+      "const_spd_const_vol_pump_motor": {
+          "key": "c_node_1",
+          "name": "Constant-speed, Constant-volume Pump and Motor",
+          "url": "https://uat-pnp.nycenergytools.com/documents/components/constant-speed-constant-volume-pump-motor/"
+      },
+      "var_spd_var_vol_pump_motor": {
+          "key": "c_node_2",
+          "name": "Variable-speed, Variable-volume Pump and Motor",
+          "url": "https://uat-pnp.nycenergytools.com/documents/components/variable-speed-variable-volume-pump-and-motor/"
+      },
+      "const_spd_const_vol_compressor_motor": {
+          "key": "c_node_3",
+          "name": "Constant-speed, Constant-volume Compressor and Motor",
+          "url": ""
+      },
+      "var_spd_var_vol_compressor_motor": {
+          "key": "c_node_4",
+          "name": "Variable-speed, Variable-volume Compressor and Motor",
+          "url": ""
+      },
+      "const_spd_const_vol_fan_motor": {
+          "key": "c_node_5",
+          "name": "Constant-speed, Constant-volume Fan and Motor",
+          "url": "https://uat-pnp.nycenergytools.com/documents/components/constant-speed-constant-volume-fan-and-motor/"
+      },
+      "var_spd_var_vol_fan_motor": {
+          "key": "c_node_6",
+          "name": "Variable-speed, Variable-volume Fan and Motor",
+          "url": "https://uat-pnp.nycenergytools.com/documents/components/variable-speed-variable-volume-fan-and-motor/"
+      },
+      "liquid_to_liquid_heat_exchanger": {
+          "key": "c_node_7",
+          "name": "Liquid-to-liquid Heat Exchanger",
+          "url": "https://uat-pnp.nycenergytools.com/documents/components/liquid-to-liquid-heat-exchanger/"
+      },
+      "air_to_air_heat_exchanger": {
+          "key": "c_node_8",
+          "name": "Air-to-air Heat Exchanger",
+          "url": "https://uat-pnp.nycenergytools.com/documents/components/air-to-air-heat-exchanger/"
+      }
+  },
+  "measurement_technicques": {
+      "lighting_fixture_runtime": {
+          "key": "mt_node_1",
+          "name": "Lighting Fixture Runtime",
+          "url": "https://uat-pnp.nycenergytools.com/documents/measurement-technique/lighting-fixture-runtime/"
+      },
+      "true_rms_power": {
+          "key": "mt_node_2",
+          "name": "True RMS Power",
+          "url": "https://uat-pnp.nycenergytools.com/documents/measurement-technique/true-rms-power/"
+      },
+      "electrical_spot_measurements": {
+          "key": "mt_node_3",
+          "name": "Electrical Spot Measurements",
+          "url": "https://uat-pnp.nycenergytools.com/documents/measurement-technique/electrical-spot-measurement/"
+      },
+      "electrical_current": {
+          "key": "mt_node_4",
+          "name": "Electrical Current",
+          "url": "https://uat-pnp.nycenergytools.com/documents/measurement-technique/electrical-current/"
+      },
+      "motor_runtime": {
+          "key": "mt_node_5",
+          "name": "Motor Runtime",
+          "url": "https://uat-pnp.nycenergytools.com/documents/measurement-technique/motor-runtime/"
+      },
+      "outdoor_air_temp": {
+          "key": "mt_node_6",
+          "name": "Outdoor Air Temperature",
+          "url": "https://uat-pnp.nycenergytools.com/documents/measurement-technique/outdoor-air-temperature/"
+      },
+      "pipe_surface_water_temp": {
+          "key": "mt_node_7",
+          "name": "Pipe Surface Water Temperature",
+          "url": "https://uat-pnp.nycenergytools.com/documents/measurement-technique/pipe-surface-water-temperature/"
+      },
+      "water_flow_rate": {
+          "key": "mt_node_8",
+          "name": "Water Flow Rate",
+          "url": "https://uat-pnp.nycenergytools.com/documents/measurement-technique/water-flow-rate/"
+      },
+      "relative_humid": {
+          "key": "mt_node_9",
+          "name": "Relative Humidity",
+          "url": "https://uat-pnp.nycenergytools.com/documents/measurement-technique/relative-humidity/"
+      },
+      "air_flow_rate": {
+          "key": "mt_node_10",
+          "name": "Air Flow Rate",
+          "url": ""
+      },
+      "system_air_temp": {
+          "key": "mt_node_11",
+          "name": "System Air Temperature",
+          "url": "https://uat-pnp.nycenergytools.com/documents/measurement-technique/system-air-temperature/"
+      }
+  },
+  "calculation_methodology": {
+      "lighting_energy_consumption": {
+          "key": "cm_node_1",
+          "name": "Lighting Energy Consumption",
+          "url": "https://uat-pnp.nycenergytools.com/documents/calculation-methodology/lighting-plant-and-systems-energy-consumption/"
+      },
+      "pump_motors_energy_consumption": {
+          "key": "cm_node_2",
+          "name": "Pump Motors Energy Consumption",
+          "url": "https://uat-pnp.nycenergytools.com/documents/calculation-methodology/pump-motors-energy-consumption/"
+      },
+      "air_cooled_chiller_energy_consumption": {
+          "key": "cm_node_3",
+          "name": "Air-cooled Chiller Energy Consumption",
+          "url": ""
+      },
+      "cooling_towers_fans_energy_consumption": {
+          "key": "cm_node_4",
+          "name": "Cooling Tower Fans Energy Consumption",
+          "url": "https://uat-pnp.nycenergytools.com/documents/calculation-methodology/cooling-tower-fans-energy-consumption/"
+      },
+      "water_cooled_chiller_energy_consumption": {
+          "key": "cm_node_5",
+          "name": "Water-cooled Chiller Energy Consumption",
+          "url": ""
+      },
+      "liquid_to_liquid_heat_exchanger_heat_transfer": {
+          "key": "cm_node_6",
+          "name": "Liquid-to-liquid Heat Exchanger Heat Transfer",
+          "url": "https://uat-pnp.nycenergytools.com/documents/calculation-methodology/liquid-to-liquid-heat-exchanger-heat-transfer/"
+      },
+      "fan_motor_energy_consumption": {
+          "key": "cm_node_7",
+          "name": "Fan Motor Energy Consumption",
+          "url": "https://uat-pnp.nycenergytools.com/documents/calculation-methodology/fan-motors-energy-consumption/"
+      },
+      "air_to_air_heat_exchanger_heat_transfer": {
+          "key": "cm_node_8",
+          "name": "Air-to-air Heat Exchanger Heat Transfer",
+          "url": "https://uat-pnp.nycenergytools.com/documents/calculation-methodology/air-to-air-heat-exchanger-heat-transfer"
+      }
+  }
+}

--- a/src/assets/jsconfig.json
+++ b/src/assets/jsconfig.json
@@ -1,0 +1,10 @@
+{
+ "compilerOptions": {
+  "baseUrl": ".",
+  "paths": {
+   "*": [
+    "*"
+   ]
+  }
+ }
+}

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -79,3 +79,13 @@ table ul {
 li > p {
   margin-bottom: .5rem;
 }
+
+.modal-dialog {
+  max-width: 100%;
+  margin: 0;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+}

--- a/src/layouts/partials/head.html
+++ b/src/layouts/partials/head.html
@@ -32,6 +32,19 @@
   {{ $style := resources.Get . | toCSS | minify }}
   <link rel="stylesheet" href="{{ $style.Permalink }}" media="screen">
   {{ end }}
+  
+  <!-- Cytoscape.js -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.30.2/cytoscape.min.js" integrity="sha512-EY3U1MWdgKx0P1dqTE4inlKz2cpXtWpsR1YUyD855Hs6RL/A0cyvrKh60EpE8wDZ814cTe1KgRK+sG0Rn792vQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  
+  <style>
+    #cy {
+      width: 100%;
+      height: 2075px;
+      display: block;
+      margin-top: 20px;
+      margin-bottom: 20px;
+    }
+  </style>
 
   {{ "<!--Favicon-->" | safeHTML }}
   <link rel="shortcut icon" href="{{ "images/favicon.ico" | absURL }}" type="image/x-icon" />

--- a/src/layouts/partials/hero.html
+++ b/src/layouts/partials/hero.html
@@ -5,7 +5,7 @@
     <div class="content align-items-center text-center">
       <div class="col-md-12" >
         <div class="hero_content text-center">
-          <div class="container content-text px-5">{{ .content | markdownify }}</div>
+          <div class="container content-text px-5">{{ .content | markdownify }} {{ partial "sitemap.html" }}</div>
           <div class="hero_content-search-bar">
             <form action="#" class="mb-0" onsubmit="doSearchGuides(guideSearchBarId);return false">
               <input id="guide-search-bar" type="search" placeholder="Search">

--- a/src/layouts/partials/sitemap.html
+++ b/src/layouts/partials/sitemap.html
@@ -1,0 +1,52 @@
+Explore our <a href="#sitemap-modal" data-toggle="modal" data-target="#sitemap-modal">content relationship diagram</a> and see how everything connects.
+<section>
+  <div
+    class="modal fade"
+    id="sitemap-modal"
+    tabindex="-1"
+    aria-labelledby="sitemap-modal"
+    aria-hidden="true"
+    style="text-align: left !important;"
+  >
+    <div
+      class="modal-dialog"
+    >
+      <div
+        class="modal-content"
+      >
+        <div
+          class="modal-header"
+        >
+          <h5
+            class="modal-title"
+          >
+            Protocols & Procedures Sitemap
+          </h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body px-5">
+          <div class="d-flex justify-content-center">
+            <div id="cy" class="border">
+              <div class="m-0 p-0" style="position: absolute; right: 0; z-index: 9999;">
+                <button id="zoom-in" type="button" style="margin-right: 5px;" class="btn btn-outline btn-dark rounded-0">
+                  <i class="fa fa-search-plus fa-lg" aria-hidden="true"></i>
+                </button>
+                <button id="zoom-out" type="button" class="btn btn-outline btn-dark rounded-0">
+                  <i class="fa fa-search-minus fa-lg" aria-hidden="true"></i>
+                </button>
+              </div>
+              {{ with resources.Get "js/cy.js" | minify }}
+                {{ with . | js.Build }}
+                    <script type="module" src="{{ .RelPermalink }}"></script>
+                {{ end }}
+              {{ end }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>


### PR DESCRIPTION
## Trello card:
- [Deploy the sitemap to UAT environment](https://trello.com/c/ZqdpXcet)

## Requirements:
- Add these files, and it’s content from [poc_sigma_js](https://github.com/charnelclamosa/poc_sigma_js) to [nycet_pnp](https://github.com/cunybpl/nycet_pnp):
  - assets/js/cy_edges.js
  - assets/js/cy_nodes.js
  - assets/js/cy.js
  - assets/js/cytoscape-dom-node.js
  - assets/js/nodes_config.js
  - layouts/partials/hero.html → Contains the HTML code for the button to open a modal that contains the sitemap
  - layouts/partials/head.html → We only need the CDN of the cytoscape.js
  - src/layouts/partials/head.html → Add this code:
```
<style>
    #cy {
      width: 100%;
      height: 2075px;
      display: block;
      margin-top: 20px;
      margin-bottom: 20px;
    }
  </style>
```
- Add this text h1 paragraph of home page: “Explore our content relationship diagram and see how everything connects.” Make the “content relationship diagram” a hyperlink that will open the modal that contains the sitemap
- The color of the modal should be same with the current color of modal for "See all -->" hyperlink

## Main Changes:
- I added the required files to render the sitemap
- I updated the HTML attributes of `modal` bootstrap class to match the `modal` class of Bootstrap 4, I had to do this because the sitemap is developed using Bootstrap 3, there is a code mismatch at first
- I modified some styles in the sitemap because there is a CSS conflict between the home page, and the sitemap. The conflict is related to alignment that makes the alignment of sitemap content broken

## Tests:
- I tested the changes on my local machine
